### PR TITLE
Add redirect for San Francisco

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,6 +26,11 @@ module.exports = withMDX({
       source: '/lisbon',
       destination: 'https://scrapyard.pt',
       permanent: true
+    },
+    {
+      source: '/san-francisco',
+      destination: 'https://scrapyardsf.com',
+      permanent: true
     }
   ]
 })


### PR DESCRIPTION
Redirect https://scrapyard.hackclub.com/san-francisco to our event-specific website, https://scrapyardsf.com/