### PR TITLE
New Scrapyard Boston Date- Regular Site

### DIFF
--- a/pages/boston/index.js
+++ b/pages/boston/index.js
@@ -173,7 +173,7 @@ export default function ExampleCity() {
                 fontSize: ['1.2em', '1.4em']
               }}
             >
-              BOSTON - March&nbsp;15-16
+              BOSTON - March&nbsp;15
             </Heading>
           </Box>
         </Box>


### PR DESCRIPTION
Scrapyard Boston currently is set to be only on March 15th